### PR TITLE
remove permission check on overview panel

### DIFF
--- a/horizon-customization/horizon_customization.py
+++ b/horizon-customization/horizon_customization.py
@@ -13,7 +13,7 @@ permissions[0] = (permissions[0],) + ('openstack.roles.cloud_admin',)
 admin_dashboard.permissions = tuple(permissions)
 
 #expose various panels to cloud_admin that require extra perms
-for apanel in ['overview', 'hypervisors', 'instances']:
+for apanel in ['hypervisors', 'instances']:
     panel = admin_dashboard.get_panel(apanel)
     panel_permissions = list(getattr(panel, 'permissions', []))
 


### PR DESCRIPTION
Permission no longer exists on overview panel:
https://github.com/openstack/horizon/commit/c2dc30cefe6d38e6272d0f6ae7b6ef06fa5c8c7c
