### PR TITLE
Remove setting permissions for the admin_dashboard.

### DIFF
--- a/horizon-customization/horizon_customization.py
+++ b/horizon-customization/horizon_customization.py
@@ -1,16 +1,7 @@
 import horizon
 
 # expose host aggregates to cloud_admin
-# default permissions for admin_dashboard _should_ be ('openstack.roles.admin',)
-# so we want to append our cloud_admin role to the first tuple
-# https://github.com/openstack/django_openstack_auth/blob/master/openstack_auth/user.py#L376
-# (('openstack.roles.admin', 'openstack.roles.cloud_admin',),) == logcal OR
 admin_dashboard = horizon.get_dashboard("admin")
-permissions = list(getattr(admin_dashboard, 'permissions', []))
-permissions[0] = (permissions[0],) + ('openstack.roles.cloud_admin',)
-
-# set admin dashboard visible to both admin, and cloud_admin
-admin_dashboard.permissions = tuple(permissions)
 
 #expose various panels to cloud_admin that require extra perms
 for apanel in ['hypervisors', 'instances']:


### PR DESCRIPTION
There has been a bugfix backported to stable mitaka. The admin
dashboard policy now includes checking the admin role against
the other policy.json files. So we don't need to override the
admin permissions but manage the roles in the policy.json files.

The bug fix commit:
https://github.com/openstack/horizon/commit/0a8b2062dbde7f1a69a5f6cff52fb4f6a6effe61
